### PR TITLE
Remove dependency on NumPy and SciPy. Lightning fast! #3

### DIFF
--- a/blackscholes/call.py
+++ b/blackscholes/call.py
@@ -1,5 +1,4 @@
-import numpy as np
-from scipy.stats import norm
+from math import exp, sqrt
 
 from .base import BlackScholesBase
 
@@ -26,8 +25,8 @@ class BlackScholesCall(BlackScholesBase):
     def price(self):
         """Price of a call option."""
         return (
-            self.S * np.exp(-self.q * self.T) * norm.cdf(self._d1)
-            - norm.cdf(self._d2) * np.exp(-self.r * self.T) * self.K
+            self.S * exp(-self.q * self.T) * self._cdf(self._d1)
+            - self._cdf(self._d2) * exp(-self.r * self.T) * self.K
         )
 
     def delta(self) -> float:
@@ -35,46 +34,46 @@ class BlackScholesCall(BlackScholesBase):
         with respect to the asset price (1st derivative).
         Proxy for probability of the option expiring in the money.
         """
-        return np.exp(-self.q * self.T) * norm.cdf(self._d1)
+        return exp(-self.q * self.T) * self._cdf(self._d1)
 
     def dual_delta(self) -> float:
         """1st derivative in option price
         with respect to strike price.
         """
-        return np.exp(-self.r * self.T) * norm.cdf(self._d2)
+        return exp(-self.r * self.T) * self._cdf(self._d2)
 
     def theta(self):
         """Rate of change in option price
         with respect to time (i.e. time decay).
         """
         return (
-            (-np.exp(-self.q * self.T) * self.S * norm.pdf(self._d1) * self.sigma)
-            / (2 * np.sqrt(self.T))
-            - (self.r * self.K * np.exp(-self.r * self.T) * norm.cdf(self._d2))
-            + self.q * self.S * np.exp(-self.q * self.T) * norm.cdf(self._d1)
+            (-exp(-self.q * self.T) * self.S * self._pdf(self._d1) * self.sigma)
+            / (2 * sqrt(self.T))
+            - (self.r * self.K * exp(-self.r * self.T) * self._cdf(self._d2))
+            + self.q * self.S * exp(-self.q * self.T) * self._cdf(self._d1)
         )
 
     def rho(self) -> float:
         """Rate of change in option price
         with respect to the risk-free rate.
         """
-        return self.K * self.T * np.exp(-self.r * self.T) * norm.cdf(self._d2)
+        return self.K * self.T * exp(-self.r * self.T) * self._cdf(self._d2)
 
     def epsilon(self) -> float:
         """Change in option price with respect to underlying dividend yield. \n
         Also known as psi."""
-        return -self.S * self.T * np.exp(-self.q * self.T) * norm.cdf(self._d1)
+        return -self.S * self.T * exp(-self.q * self.T) * self._cdf(self._d1)
 
     def charm(self) -> float:
         """Rate of change of delta over time (also known as delta decay)."""
-        return self.q * np.exp(-self.q * self.T) * norm.cdf(self._d1) - np.exp(
+        return self.q * exp(-self.q * self.T) * self._cdf(self._d1) - exp(
             -self.q * self.T
-        ) * norm.pdf(self._d1) * (
-            2 * (self.r - self.q) * self.T - self._d2 * self.sigma * np.sqrt(self.T)
+        ) * self._pdf(self._d1) * (
+            2 * (self.r - self.q) * self.T - self._d2 * self.sigma * sqrt(self.T)
         ) / (
-            2 * self.T * self.sigma * np.sqrt(self.T)
+            2 * self.T * self.sigma * sqrt(self.T)
         )
 
     def in_the_money(self):
         """Naive Probability that call option will be in the money at maturity."""
-        return norm.cdf(self._d2)
+        return self._cdf(self._d2)

--- a/blackscholes/put.py
+++ b/blackscholes/put.py
@@ -1,5 +1,4 @@
-import numpy as np
-from scipy.stats import norm
+from math import exp, sqrt
 
 from .base import BlackScholesBase
 
@@ -25,56 +24,56 @@ class BlackScholesPut(BlackScholesBase):
 
     def price(self):
         """Price of a put option."""
-        return norm.cdf(-self._d2) * self.K * np.exp(
-            -self.r * self.T
-        ) - self.S * np.exp(-self.q * self.T) * norm.cdf(-self._d1)
+        return self._cdf(-self._d2) * self.K * exp(-self.r * self.T) - self.S * exp(
+            -self.q * self.T
+        ) * self._cdf(-self._d1)
 
     def delta(self):
         """
         Rate of change in option price
         with respect to the asset price (1st derivative).
         """
-        return -np.exp(-self.q * self.T) * norm.cdf(-self._d1)
+        return -exp(-self.q * self.T) * self._cdf(-self._d1)
 
     def dual_delta(self):
         """1st derivative in option price
         with respect to strike price.
         """
-        return np.exp(-self.r * self.T) * norm.cdf(-self._d2)
+        return exp(-self.r * self.T) * self._cdf(-self._d2)
 
     def theta(self):
         """Rate of change in option price
         with respect to time (i.e. time decay).
         """
         return (
-            (-np.exp(self.q * self.T) * self.S * norm.pdf(self._d1) * self.sigma)
-            / (2 * np.sqrt(self.T))
+            (-exp(self.q * self.T) * self.S * self._pdf(self._d1) * self.sigma)
+            / (2 * sqrt(self.T))
         ) + (
-            self.r * self.K * np.exp(-self.r * self.T) * norm.cdf(-self._d2)
-            - self.q * self.S * np.exp(-self.q * self.T) * norm.cdf(-self._d1)
+            self.r * self.K * exp(-self.r * self.T) * self._cdf(-self._d2)
+            - self.q * self.S * exp(-self.q * self.T) * self._cdf(-self._d1)
         )
 
     def rho(self) -> float:
         """Rate of change in option price
         with respect to the risk-free rate.
         """
-        return -self.K * self.T * np.exp(-self.r * self.T) * norm.cdf(-self._d2)
+        return -self.K * self.T * exp(-self.r * self.T) * self._cdf(-self._d2)
 
     def epsilon(self) -> float:
         """Change in option price with respect to underlying dividend yield. \n
         Also known as psi."""
-        return self.S * self.T * np.exp(-self.q * self.T) * norm.cdf(-self._d1)
+        return self.S * self.T * exp(-self.q * self.T) * self._cdf(-self._d1)
 
     def charm(self) -> float:
         """Rate of change of delta over time (also known as delta decay)."""
-        return -self.q * np.exp(-self.q * self.T) * norm.cdf(-self._d1) - np.exp(
+        return -self.q * exp(-self.q * self.T) * self._cdf(-self._d1) - exp(
             -self.q * self.T
-        ) * norm.pdf(self._d1) * (
-            2 * (self.r - self.q) * self.T - self._d2 * self.sigma * np.sqrt(self.T)
+        ) * self._pdf(self._d1) * (
+            2 * (self.r - self.q) * self.T - self._d2 * self.sigma * sqrt(self.T)
         ) / (
-            2 * self.T * self.sigma * np.sqrt(self.T)
+            2 * self.T * self.sigma * sqrt(self.T)
         )
 
     def in_the_money(self):
         """Naive Probability that put option will be in the money at maturity."""
-        return 1 - norm.cdf(self._d2)
+        return 1 - self._cdf(self._d2)

--- a/blackscholes/tests/test_base.py
+++ b/blackscholes/tests/test_base.py
@@ -33,6 +33,9 @@ class BlackScholesMeta(BlackScholesBase):
     def rho(self):
         ...
 
+    def charm(self):
+        ...
+
 
 class TestBlackScholesBase:
     test_S = 55.0  # Asset price of 55

--- a/blackscholes/tests/test_call.py
+++ b/blackscholes/tests/test_call.py
@@ -27,7 +27,7 @@ class TestBlackScholesCall:
             r=self.test_r,
             sigma=self.test_sigma,
         )
-        assert call_delta - put.delta() == 1.0
+        np.testing.assert_almost_equal(call_delta - put.delta(), 1.0, decimal=5)
 
     def test_dual_delta(self):
         call_delta = self.call.dual_delta()

--- a/blackscholes/tests/test_put.py
+++ b/blackscholes/tests/test_put.py
@@ -27,7 +27,7 @@ class TestBlackScholesPut:
             r=self.test_r,
             sigma=self.test_sigma,
         )
-        assert call.delta() - put_delta == 1.0
+        np.testing.assert_almost_equal(call.delta() - put_delta, 1.0, decimal=5)
 
     def test_dual_delta(self):
         put_delta = self.put.dual_delta()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ readme = ".github/README.MD"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-scipy = "^1.9.3"
 numpy = "^1.23.5"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Solves #3 

Lightning fast computation due to reduced dependency. Only uses Python standard library now. NumPy only used for testing and removed dependency on SciPy entirely.

Implementing JIT compilation is probably not worth it. Can revisit it later.