### PR TITLE
fix: cash-or-nothing greeks, Black-76 validation, structure gearing

### DIFF
--- a/docs/2.price.md
+++ b/docs/2.price.md
@@ -97,6 +97,8 @@ put.price()  ## 1.2470
 
 `blackscholes` supports calculation of the price and the forward (undiscounted price) of binary options. Also called a digital, exotic or bet option.
 
+These are **cash-or-nothing** contracts with **cash amount $1$** (not $K$) and **no dividend yield** ($q=0$): the call pays $1$ if $S_T>K$ and $0$ otherwise; the put pays $1$ if $S_T<K$.
+
 ### Call
 
 $$e^{-rT} \Phi(d_2)$$

--- a/docs/3.the_greeks_blackscholes.md
+++ b/docs/3.the_greeks_blackscholes.md
@@ -87,7 +87,7 @@ Symbol for Vega is `$\mathcal{V}$`.
 
 Unit: percentage (regular form).
 
-$$S\phi(d_1)\sqrt(T)$$
+$$S e^{-qT}\phi(d_1)\sqrt{T}$$
 
 ::: blackscholes.base.BlackScholesBase.vega
 
@@ -154,9 +154,9 @@ where `$\Delta$` indicates the [Delta Greek](#delta).
 
 ### Vanna
 
-$$\frac{\mathcal{V}}{S}\bigg[ 1-\frac{d_1}{\sigma\sqrt{T}} \bigg]$$
+$$-e^{-qT}\frac{\phi(d_1) d_2}{\sigma}$$
 
-where `$\mathcal{V}$` indicates the [Vega Greek](#vega).
+(equivalent to $\mathcal{V}\cdot\frac{-d_2}{S\sigma\sqrt{T}}$ with [Vega](#vega) $\mathcal{V}=S e^{-qT}\phi(d_1)\sqrt{T}$).
 
 ::: blackscholes.base.BlackScholesBase.vanna
 
@@ -252,19 +252,30 @@ $$e^{-rT} \frac{\phi(d_2)}{K\sigma\sqrt{T}}$$
 
 Binary options are also called exotic, digital or bet options.
 
+This library implements **cash-or-nothing** binaries with **cash amount $= 1$**
+(payoff $1_{\{S_T > K\}}$ for the call and $1_{\{S_T < K\}}$ for the put).
+Dividend yield is assumed to be $q=0$. The price is
+
+$$
+V_{\text{call}} = e^{-rT}\Phi(d_2),\qquad
+V_{\text{put}} = e^{-rT}\Phi(-d_2).
+$$
+
+Greeks below are the analytic partial derivatives of that price (not vanilla BSM building blocks).
+
 ### Delta
 
 Symbol for Delta is `$\Delta$`.
 
 #### Call
 
-$$\frac{e^{-rT}}{\sqrt{T}}\phi(d_1)$$
+$$e^{-rT}\frac{\phi(d_2)}{S\sigma\sqrt{T}}$$
 
 ::: blackscholes.call.BinaryCall.delta
 
 #### Put
 
-$$-\frac{e^{-rT}}{\sqrt{T}}\phi(d_1)$$
+$$-e^{-rT}\frac{\phi(d_2)}{S\sigma\sqrt{T}}$$
 
 ::: blackscholes.put.BinaryPut.delta
 
@@ -272,39 +283,55 @@ $$-\frac{e^{-rT}}{\sqrt{T}}\phi(d_1)$$
 
 Symbol for Gamma is `$\Gamma$`.
 
-$$\frac{\phi(d_1) (\frac{d_1}{T \sigma S} - \frac{1}{S^2})}{S \sigma \sqrt{T}}$$
+#### Call
+
+$$-e^{-rT}\frac{\phi(d_2)\, d_1}{S^{2}\sigma^{2} T}$$
 
 ::: blackscholes.base.BinaryBase.gamma
+
+#### Put
+
+$$\Gamma_{\text{put}} = -\Gamma_{\text{call}}$$
+
+::: blackscholes.put.BinaryPut.gamma
 
 ### Vega
 
 Symbol for Vega is `$\mathcal{V}$`.
 
-Note that the Vega for the put is the negative of the Vega for the call. This is a peculiarity of binary options. For vanilla option the Vega for the put is the same as the Vega for the call, but not for the case of binary options.
+Note that put vega is the negative of call vega for cash-or-nothing binaries
+(unlike vanilla options, where call and put vegas coincide when $q=0$).
 
 #### Call
 
-$$S \sqrt{T} \phi(d_1) \frac{d_1}{\sigma}$$
+$$-e^{-rT}\frac{\phi(d_2)\, d_1}{\sigma}$$
 
 ::: blackscholes.call.BinaryCall.vega
 
 #### Put
 
-$$- S \sqrt{T} \phi(d_1) \frac{d_1}{\sigma}$$
+$$e^{-rT}\frac{\phi(d_2)\, d_1}{\sigma}$$
 
 ::: blackscholes.put.BinaryPut.vega
 
 ### Theta
 
+Calendar theta $\Theta = -\partial V/\partial T$. With
+
+$$
+\frac{\partial d_2}{\partial T}
+= -\frac{d_2}{2T} + \frac{r - \tfrac{1}{2}\sigma^{2}}{\sigma\sqrt{T}},
+$$
+
 #### Call
 
-$$r K e^{-rT} \Phi(d_2) - \frac{S \phi(d_1) \sigma}{2 \sqrt{T}}$$
+$$e^{-rT}\Big[r\,\Phi(d_2) - \phi(d_2)\frac{\partial d_2}{\partial T}\Big]$$
 
 ::: blackscholes.call.BinaryCall.theta
 
 #### Put
 
-$$- r K e^{-rT} \Phi(-d_2) - \frac{S \phi(d_1) \sigma}{2 \sqrt{T}}$$
+$$e^{-rT}\Big[r\,\Phi(-d_2) + \phi(d_2)\frac{\partial d_2}{\partial T}\Big]$$
 
 ::: blackscholes.put.BinaryPut.theta
 
@@ -312,12 +339,12 @@ $$- r K e^{-rT} \Phi(-d_2) - \frac{S \phi(d_1) \sigma}{2 \sqrt{T}}$$
 
 #### Call
 
-$$T K e^{-rT} \Phi(d_2)$$
+$$e^{-rT}\Big[-T\,\Phi(d_2) + \phi(d_2)\frac{\sqrt{T}}{\sigma}\Big]$$
 
 ::: blackscholes.call.BinaryCall.rho
 
 #### Put
 
-$$- T K e^{-rT} \Phi(-d_2)$$
+$$e^{-rT}\Big[-T\,\Phi(-d_2) - \phi(d_2)\frac{\sqrt{T}}{\sigma}\Big]$$
 
 ::: blackscholes.put.BinaryPut.rho

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,7 +190,7 @@ iron_butterfly.delta()  ## 0.0001
 
 ### Binary options
 
-Binary options are also called exotic, digital or bet options. `blackscholes` supports Greeks for binary calls and puts.
+Binary options are also called exotic, digital or bet options. `blackscholes` supports **cash-or-nothing** (cash amount $1$, $q=0$) prices and Greeks for binary calls and puts.
 
 
 

--- a/src/blackscholes/base.py
+++ b/src/blackscholes/base.py
@@ -97,7 +97,7 @@ class BlackScholesBase(ABC, StandardNormalMixin):
         """
         Rate of change in option price with respect to the volatility of the asset.
         """
-        return self.S * self._pdf(self._d1) * sqrt(self.T)
+        return self.S * exp(-self.q * self.T) * self._pdf(self._d1) * sqrt(self.T)
 
     @abstractmethod
     def theta(self) -> float:
@@ -128,7 +128,7 @@ class BlackScholesBase(ABC, StandardNormalMixin):
 
     def vanna(self) -> float:
         """Sensitivity of delta with respect to change in volatility."""
-        return -self._pdf(self._d1) * self._d2 / self.sigma
+        return -exp(-self.q * self.T) * self._pdf(self._d1) * self._d2 / self.sigma
 
     @abstractmethod
     def charm(self) -> float:
@@ -292,11 +292,11 @@ class Black76Base(ABC, StandardNormalMixin):
     """
 
     def __init__(self, F: float, K: float, T: float, r: float, sigma: float):
-        # Some parameters must be positive
-        for param in [F, K, T, sigma]:
+        # F, K, T, sigma must be strictly positive (zeros break log/d1/gamma)
+        for name, param in ("F", F), ("K", K), ("T", T), ("sigma", sigma):
             assert (
-                param >= 0.0
-            ), f"Some parameters cannot be negative. Got '{param}' as an argument."
+                param > 0.0
+            ), f"{name} needs to be larger than 0. Got '{param}'"
         self.F, self.K, self.T, self.r, self.sigma = F, K, T, r, sigma
 
     @abstractmethod
@@ -490,8 +490,9 @@ class BlackScholesStructureBase(ABC):
     def lambda_greek(self) -> float:
         """Percentage change in structure price per %
         change in asset price. Also called gearing.
+        Computed on the aggregate (not sum of leg gearings).
         """
-        return self._calc_attr(attribute_name="lambda_greek")
+        return self.delta() * self._underlying_spot() / self.price()
 
     def vanna(self) -> float:
         """Sensitivity of delta with respect to change in volatility."""
@@ -538,8 +539,16 @@ class BlackScholesStructureBase(ABC):
     def alpha(self) -> float:
         """Theta to gamma ratio. Also called "gamma rent".
         More info: "Dynamic Hedging" by Nassim Taleb, p. 178-181.
+        Computed on the aggregate (not sum of leg alphas).
         """
-        return self._calc_attr(attribute_name="alpha")
+        return abs(self.theta()) / (self.gamma() + 1e-9)
+
+    def _underlying_spot(self) -> float:
+        """Spot of the common underlying (from any leg with attribute S)."""
+        for leg in self.__dict__.values():
+            if hasattr(leg, "S"):
+                return leg.S
+        raise AttributeError("No option leg with spot price S found on structure")
 
     def get_core_greeks(self) -> Dict[str, float]:
         """
@@ -636,11 +645,23 @@ class BinaryBase(ABC, StandardNormalMixin):
         """
         ...
 
+    def _d2_dT(self) -> float:
+        """Partial of d2 with respect to time-to-maturity T (q=0)."""
+        return -self._d2 / (2.0 * self.T) + (
+            self.r - 0.5 * self.sigma**2
+        ) / (self.sigma * sqrt(self.T))
+
     def gamma(self) -> float:
-        """Rate of change in delta
-        with respect to the underlying price (2nd derivative).
+        """Cash-or-nothing call gamma (put subclasses negate).
+
+        Γ_call = -e^{-rT} n(d2) d1 / (S² σ² T)
         """
-        return (self._pdf(self._d1) * (self._d1 / (self.T * self.sigma * self.S) - 1 / self.S**2)) / (self.S * self.sigma * sqrt(self.T))
+        return (
+            -exp(-self.r * self.T)
+            * self._pdf(self._d2)
+            * self._d1
+            / (self.S**2 * self.sigma**2 * self.T)
+        )
 
     @abstractmethod
     def vega(self) -> float:

--- a/src/blackscholes/call.py
+++ b/src/blackscholes/call.py
@@ -165,27 +165,33 @@ class BinaryCall(BinaryBase):
         return self._cdf(self._d2)
     
     def delta(self) -> float:
-        """Rate of change in option price
-        with respect to the forward price (1st derivative).
-        Note that this is the forward delta.
-        """
-        return exp(-self.r * self.T) * self._pdf(self._d1) / sqrt(self.T)
-    
+        """Cash-or-nothing call delta: e^{-rT} n(d2) / (S σ √T)."""
+        return (
+            exp(-self.r * self.T)
+            * self._pdf(self._d2)
+            / (self.S * self.sigma * sqrt(self.T))
+        )
+
     def vega(self) -> float:
-        """Rate of change in option price
-        with respect to the volatility (1st derivative).
-        """
-        return self.S * sqrt(self.T) * self._pdf(self._d1) * self._d1 / self.sigma
-    
+        """Cash-or-nothing call vega: -e^{-rT} n(d2) d1 / σ."""
+        return (
+            -exp(-self.r * self.T)
+            * self._pdf(self._d2)
+            * self._d1
+            / self.sigma
+        )
+
     def theta(self) -> float:
-        """Rate of change in option price
-        with respect to time (i.e. time decay).
-        """
-        return self.r * self.K * exp(-self.r * self.T) * self._cdf(self._d2) - (self.S * self._pdf(self._d1) * self.sigma) / (2 * sqrt(self.T))
-    
+        """Cash-or-nothing call theta (∂V/∂t = -∂V/∂T)."""
+        return exp(-self.r * self.T) * (
+            self.r * self._cdf(self._d2)
+            - self._pdf(self._d2) * self._d2_dT()
+        )
+
     def rho(self) -> float:
-        """Rate of change in option price
-        with respect to the risk-free rate.
-        """
-        return self.T * self.K * exp(-self.r * self.T) * self._cdf(self._d2)
+        """Cash-or-nothing call rho: e^{-rT} [-T N(d2) + n(d2) √T / σ]."""
+        return exp(-self.r * self.T) * (
+            -self.T * self._cdf(self._d2)
+            + self._pdf(self._d2) * sqrt(self.T) / self.sigma
+        )
     

--- a/src/blackscholes/put.py
+++ b/src/blackscholes/put.py
@@ -155,26 +155,37 @@ class BinaryPut(BinaryBase):
         return 1 - self._cdf(self._d2)
     
     def delta(self) -> float:
-        """Rate of change in option price
-        with respect to the underlying price (1st derivative).
-        """
-        return -exp(-self.r * self.T) * self._pdf(self._d1) / sqrt(self.T)
-    
+        """Cash-or-nothing put delta: -e^{-rT} n(d2) / (S σ √T)."""
+        return (
+            -exp(-self.r * self.T)
+            * self._pdf(self._d2)
+            / (self.S * self.sigma * sqrt(self.T))
+        )
+
+    def gamma(self) -> float:
+        """Cash-or-nothing put gamma = -call gamma."""
+        return -super().gamma()
+
     def vega(self) -> float:
-        """Rate of change in option price
-        with respect to the volatility (1st derivative).
-        """
-        return -self.S * sqrt(self.T) * self._pdf(self._d1) * self._d1 / self.sigma
-    
+        """Cash-or-nothing put vega: e^{-rT} n(d2) d1 / σ."""
+        return (
+            exp(-self.r * self.T)
+            * self._pdf(self._d2)
+            * self._d1
+            / self.sigma
+        )
+
     def theta(self) -> float:
-        """Rate of change in option price
-        with respect to time (i.e. time decay).
-        """
-        return -self.r * self.K * exp(-self.r * self.T) * self._cdf(-self._d2) - (self.S * self._pdf(self._d1) * self.sigma) / (2 * sqrt(self.T))
-    
+        """Cash-or-nothing put theta (∂V/∂t = -∂V/∂T)."""
+        return exp(-self.r * self.T) * (
+            self.r * self._cdf(-self._d2)
+            + self._pdf(self._d2) * self._d2_dT()
+        )
+
     def rho(self) -> float:
-        """Rate of change in option price
-        with respect to the risk-free rate.
-        """
-        return -(self.T * self.K * exp(-self.r * self.T) * self._cdf(-self._d2))
+        """Cash-or-nothing put rho: e^{-rT} [-T N(-d2) - n(d2) √T / σ]."""
+        return exp(-self.r * self.T) * (
+            -self.T * self._cdf(-self._d2)
+            - self._pdf(self._d2) * sqrt(self.T) / self.sigma
+        )
     

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -173,36 +173,17 @@ class TestBlack76Base:
     meta = Black76Meta(F=test_S, K=test_K, T=test_T, r=test_r, sigma=test_sigma)
 
     def test_arg_assert(self):
-        # Should not be able to initialize if F, K, T, or sigma is negative.
-        with pytest.raises(AssertionError):
-            Black76Meta(
-                F=-test_S,
-                K=test_K,
-                T=test_T,
-                r=test_r,
-                sigma=test_sigma,
-            )
-            Black76Meta(
-                F=test_S,
-                K=-test_K,
-                T=test_T,
-                r=test_r,
-                sigma=test_sigma,
-            )
-            Black76Meta(
-                F=-test_S,
-                K=test_K,
-                T=-test_T,
-                r=test_r,
-                sigma=test_sigma,
-            )
-            Black76Meta(
-                F=test_S,
-                K=test_K,
-                T=test_T,
-                r=test_r,
-                sigma=-test_sigma,
-            )
+        # F, K, T, sigma must be strictly positive (zeros and negatives rejected).
+        for kwargs in (
+            dict(F=-test_S, K=test_K, T=test_T, r=test_r, sigma=test_sigma),
+            dict(F=0.0, K=test_K, T=test_T, r=test_r, sigma=test_sigma),
+            dict(F=test_S, K=0.0, T=test_T, r=test_r, sigma=test_sigma),
+            dict(F=test_S, K=test_K, T=0.0, r=test_r, sigma=test_sigma),
+            dict(F=test_S, K=test_K, T=test_T, r=test_r, sigma=0.0),
+            dict(F=test_S, K=test_K, T=test_T, r=test_r, sigma=-test_sigma),
+        ):
+            with pytest.raises(AssertionError):
+                Black76Meta(**kwargs)
 
         # Initializing with negative r (interest rate) is possible.
         Black76Meta(
@@ -311,4 +292,4 @@ class TestBinaryBase:
 
     def test_gamma(self):
         gamma = self.meta.gamma()
-        np.testing.assert_almost_equal(gamma, 0.0032595297589864043, decimal=6)
+        np.testing.assert_almost_equal(gamma, -0.003598982722841523, decimal=6)

--- a/tests/test_butterfly.py
+++ b/tests/test_butterfly.py
@@ -36,6 +36,8 @@ class TestBlackScholesButterflyLong:
         test_methods = list(butterfly.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Long (call) butterfly = Call1 - 2 * Call2 + Call3
         for attr in test_methods:
             assert (
@@ -70,6 +72,8 @@ class TestBlackScholesButterflyShort:
         test_methods = list(butterfly.put1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Short (put) butterfly = -Put1 + 2 * Put2 - Put3
         for attr in test_methods:
             assert (

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -233,36 +233,36 @@ class TestBinaryCall:
 
     def test_delta(self):
         delta = self.call.delta()
-        np.testing.assert_almost_equal(delta, 0.3055162306516324, decimal=6)
+        np.testing.assert_almost_equal(delta, 0.04083746356834601, decimal=6)
 
     def test_gamma(self):
         gamma = self.call.gamma()
         put_gamma = self.put.gamma()
-        np.testing.assert_almost_equal(gamma, put_gamma, decimal=15)
-        np.testing.assert_almost_equal(gamma, 0.0032595297589864043, decimal=6)
+        np.testing.assert_almost_equal(gamma, -put_gamma, decimal=12)
+        np.testing.assert_almost_equal(gamma, -0.003598982722841523, decimal=6)
 
     def test_vega(self):
         vega = self.call.vega()
         put_vega = self.put.vega()
-        np.testing.assert_almost_equal(vega, -put_vega, decimal=15)
-        np.testing.assert_almost_equal(vega, 81.65192052446703, decimal=6)
+        np.testing.assert_almost_equal(vega, -put_vega, decimal=12)
+        np.testing.assert_almost_equal(vega, -1.6330384104893412, decimal=6)
 
     def test_theta(self):
         theta = self.call.theta()
-        np.testing.assert_almost_equal(theta, -1.1738764912159139, decimal=6)
+        np.testing.assert_almost_equal(theta, 0.11865338030464881, decimal=6)
 
     def test_rho(self):
         rho = self.call.rho()
-        np.testing.assert_almost_equal(rho, 35.813015171916085, decimal=6)
+        np.testing.assert_almost_equal(rho, 1.5298001928207086, decimal=6)
 
     def test_get_core_greeks(self):
         core_greeks = self.call.get_core_greeks()
         expected_result = {
-            "delta": 0.3055162306516324,
-            "gamma": 0.0032595297589864043,
-            "vega": 81.65192052446703,
-            "theta": -1.1738764912159139,
-            "rho": 35.813015171916085,
+            "delta": 0.04083746356834601,
+            "gamma": -0.003598982722841523,
+            "vega": -1.6330384104893412,
+            "theta": 0.11865338030464881,
+            "rho": 1.5298001928207086,
         }
 
         assert set(core_greeks.keys()) == set(expected_result.keys())
@@ -270,4 +270,20 @@ class TestBinaryCall:
             np.testing.assert_almost_equal(
                 core_greeks[key], expected_result[key], decimal=5
             )
+
+    def test_greeks_match_finite_differences(self):
+        """Cash-or-nothing greeks should match central finite differences on price."""
+        eps = 1e-5
+        S, K, T, r, sigma = test_S, test_K, test_T, test_r, test_sigma
+        c = self.call
+
+        def price(**kw):
+            return BinaryCall(**{**dict(S=S, K=K, T=T, r=r, sigma=sigma), **kw}).price()
+
+        fd_delta = (price(S=S + eps) - price(S=S - eps)) / (2 * eps)
+        fd_vega = (price(sigma=sigma + eps) - price(sigma=sigma - eps)) / (2 * eps)
+        fd_rho = (price(r=r + eps) - price(r=r - eps)) / (2 * eps)
+        np.testing.assert_allclose(c.delta(), fd_delta, rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(c.vega(), fd_vega, rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(c.rho(), fd_rho, rtol=1e-5, atol=1e-7)
 

--- a/tests/test_iron_butterfly.py
+++ b/tests/test_iron_butterfly.py
@@ -74,6 +74,8 @@ class TestBlackScholesIronButterflyLong:
         test_methods = list(iron_butterfly.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Long iron butterfly = -Put1 + Put2 + Call1 - Call2
         for attr in test_methods:
             assert (
@@ -147,6 +149,8 @@ class TestBlackScholesIronButterflyShort:
         test_methods = list(iron_butterfly.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Short iron butterfly = Put1 - Put2 - Call1 + Call2
         for attr in test_methods:
             assert (

--- a/tests/test_iron_condor.py
+++ b/tests/test_iron_condor.py
@@ -69,6 +69,8 @@ class TestBlackScholesIronCondorLong:
         test_methods = list(iron_condor.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Long iron condor = -Put1 + Put2 + Call1 - Call2
         for attr in test_methods:
             assert (
@@ -136,6 +138,8 @@ class TestBlackScholesIronCondorShort:
         test_methods = list(iron_condor.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Short iron condor = Put1 - Put2 - Call1 + Call2
         for attr in test_methods:
             assert (

--- a/tests/test_put.py
+++ b/tests/test_put.py
@@ -66,6 +66,25 @@ class TestBlackScholesPut:
         put_theta = self.put.theta()
         np.testing.assert_almost_equal(put_theta, -1.2282536767758119, decimal=6)
 
+    def test_theta_with_dividend(self):
+        # With q>0, put theta density term must use exp(-qT) (not exp(+qT)).
+        put_q = BlackScholesPut(
+            S=test_S, K=test_K, T=test_T, r=test_r, sigma=test_sigma, q=0.05
+        )
+        call_q = BlackScholesCall(
+            S=test_S, K=test_K, T=test_T, r=test_r, sigma=test_sigma, q=0.05
+        )
+        # Put-call theta parity (continuous dividend): theta_C - theta_P = q S e^{-qT} - r K e^{-rT}
+        from math import exp
+
+        lhs = call_q.theta() - put_q.theta()
+        rhs = (
+            0.05 * test_S * exp(-0.05 * test_T)
+            - test_r * test_K * exp(-test_r * test_T)
+        )
+        np.testing.assert_almost_equal(lhs, rhs, decimal=6)
+
+
     def test_epsilon(self):
         call_epsilon = self.put.epsilon()
         np.testing.assert_almost_equal(call_epsilon, 12.84757053197959, decimal=6)
@@ -218,36 +237,36 @@ class TestBinaryPut:
 
     def test_delta(self):
         delta = self.put.delta()
-        np.testing.assert_almost_equal(delta, -0.3055162306516324, decimal=6)
+        np.testing.assert_almost_equal(delta, -0.04083746356834601, decimal=6)
 
     def test_gamma(self):
         gamma = self.put.gamma()
         call_gamma = self.call.gamma()
-        np.testing.assert_almost_equal(gamma, call_gamma, decimal=16)
-        np.testing.assert_almost_equal(gamma, 0.0032595297589864043, decimal=6)
+        np.testing.assert_almost_equal(gamma, -call_gamma, decimal=12)
+        np.testing.assert_almost_equal(gamma, 0.003598982722841523, decimal=6)
 
     def test_vega(self):
         vega = self.put.vega()
         call_vega = self.call.vega()
-        np.testing.assert_almost_equal(vega, -call_vega, decimal=16)
-        np.testing.assert_almost_equal(vega, -81.65192052446703, decimal=6)
+        np.testing.assert_almost_equal(vega, -call_vega, decimal=12)
+        np.testing.assert_almost_equal(vega, 1.6330384104893412, decimal=6)
 
     def test_theta(self):
         theta = self.put.theta()
-        np.testing.assert_almost_equal(theta, -1.2985643815155963, decimal=6)
+        np.testing.assert_almost_equal(theta, -0.11615962249865515, decimal=6)
 
     def test_rho(self):
         rho = self.put.rho()
-        np.testing.assert_almost_equal(rho, -14.062140947956921, decimal=6)
+        np.testing.assert_almost_equal(rho, -2.5273033152181688, decimal=6)
 
     def test_get_core_greeks(self):
         core_greeks = self.put.get_core_greeks()
         expected_result = {
-            "delta": -0.3055162306516324,
-            "gamma": 0.0032595297589864043,
-            "vega": -81.65192052446703,
-            "theta": -1.2985643815155963,
-            "rho": -14.062140947956921,
+            "delta": -0.04083746356834601,
+            "gamma": 0.003598982722841523,
+            "vega": 1.6330384104893412,
+            "theta": -0.11615962249865515,
+            "rho": -2.5273033152181688,
         }
 
         assert set(core_greeks.keys()) == set(expected_result.keys())

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -28,6 +28,8 @@ class TestBlackScholesBullSpread:
         test_methods = list(spread.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Bull spread = Call1 - Call2
         for attr in test_methods:
             assert (
@@ -51,6 +53,8 @@ class TestBlackScholesBearSpread:
         test_methods = list(spread.put1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Bear spread = Put1 - Put2
         for attr in test_methods:
             assert (
@@ -73,6 +77,8 @@ class TestBlackScholesCalendarCallSpread:
         test_methods = list(spread.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Calendar Call Spread = Call1 - Call2
         for attr in test_methods:
             assert (
@@ -95,6 +101,8 @@ class TestBlackScholesCalendarPutSpread:
         test_methods = list(spread.put1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Calendar Put Spread = Put1 - Put2
         for attr in test_methods:
             assert (

--- a/tests/test_straddle.py
+++ b/tests/test_straddle.py
@@ -14,6 +14,8 @@ class TestBlackScholesStraddleLong:
         test_methods = list(straddle.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Long straddle = Put1 + Call1
         for attr in test_methods:
             assert (
@@ -28,6 +30,8 @@ class TestBlackScholesStraddleShort:
         test_methods = list(straddle.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Short straddle = - Put1 - Call1
         for attr in test_methods:
             assert (

--- a/tests/test_strangle.py
+++ b/tests/test_strangle.py
@@ -26,6 +26,8 @@ class TestBlackScholesStrangleLong:
         test_methods = list(strangle.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Long strangle = Put1 + Call1
         for attr in test_methods:
             assert (
@@ -49,6 +51,8 @@ class TestBlackScholesStrangleShort:
         test_methods = list(strangle.call1.get_all_greeks().keys()) + [
             "price",
         ]
+        # lambda/alpha are structure-level (not sum of leg ratios)
+        test_methods = [m for m in test_methods if m not in ("lambda_greek", "alpha")]
         # Short strangle = -Put1 - Call1
         for attr in test_methods:
             assert (


### PR DESCRIPTION
## Summary
- **Binary (cash-or-nothing) greeks**: rewrite delta/gamma/vega/theta/rho to standard cash-or-nothing BSM (validated with central finite differences). Prior formulas mixed in vanilla-style terms and used `n(d1)/√T` for delta.
- **Black-76 inputs**: require `F, K, T, sigma > 0` (zeros caused `log(0)` / divide-by-zero in `_d1`/`gamma`).
- **BSM vega/vanna**: multiply by `e^{-qT}`.
- **Structures**: `lambda_greek` / `alpha` computed on aggregate price/greeks (not sum of leg ratios).
- **Note:** put `theta` with `exp(-qT)` is already on `main` (PR #26).

## Test plan
- [x] `uv run pytest` — 103 passed
- [x] `uv run ruff check src tests`
- [x] Binary call greeks vs FD in `test_greeks_match_finite_differences`
- [x] Put–call theta parity with `q=0.05`
- [x] Black76 rejects zero/negative `F,K,T,sigma`